### PR TITLE
Fix default value

### DIFF
--- a/src/reducers/socialSettingsReducer.js
+++ b/src/reducers/socialSettingsReducer.js
@@ -3,7 +3,7 @@ import { GET_SOCIAL_SETTINGS } from '../actions/getSocialSettings';
 const initialState = {
   error: null,
   hasErrror: false,
-  results: {},
+  results: null,
   loadingResults: false,
 };
 


### PR DESCRIPTION
api call return an array and not an object.

If we set it as null, we can better manage checks if the settings are already loaded but they are empty ([]) or has not  been loaded yet (null).