### PR TITLE
fix: fixed twitter x icon

### DIFF
--- a/src/components/SocialLinks/SocialLinks.jsx
+++ b/src/components/SocialLinks/SocialLinks.jsx
@@ -10,6 +10,11 @@ import { getSocialSettings } from '../../actions/getSocialSettings';
 import { Icon } from 'semantic-ui-react';
 import cx from 'classnames';
 
+// temporary fix for twitter-x icon
+import { Icon as IconCustom } from '@plone/volto/components';
+import twitterXSvg from '../icons/twitter-x.svg';
+import './socialLinks.css';
+
 const SocialLinks = ({ wrapperCssClass, itemCssClass }) => {
   const socialSettings = useSelector((state) => state.socialSettings?.results);
   const dispatch = useDispatch();
@@ -32,7 +37,15 @@ const SocialLinks = ({ wrapperCssClass, itemCssClass }) => {
             title={title}
             key={url}
           >
-            <Icon name={icon} />
+            {icon === 'twitter-x' ? (
+              <IconCustom 
+                className="custom-icon"
+                size="24px"
+                name={twitterXSvg}
+              />
+            ) : (
+              <Icon name={icon} />
+            )}
           </a>
         );
       })}

--- a/src/components/SocialLinks/SocialLinks.jsx
+++ b/src/components/SocialLinks/SocialLinks.jsx
@@ -11,7 +11,7 @@ import { Icon } from 'semantic-ui-react';
 import cx from 'classnames';
 
 // temporary fix for twitter-x icon
-import { Icon as IconCustom } from '@plone/volto/components';
+import { Icon as VoltoIcon } from '@plone/volto/components';
 import twitterXSvg from '../icons/twitter-x.svg';
 import './socialLinks.css';
 
@@ -38,7 +38,7 @@ const SocialLinks = ({ wrapperCssClass, itemCssClass }) => {
             key={url}
           >
             {icon === 'twitter-x' ? (
-              <IconCustom 
+              <VoltoIcon 
                 className="custom-icon"
                 size="24px"
                 name={twitterXSvg}

--- a/src/components/SocialLinks/socialLinks.css
+++ b/src/components/SocialLinks/socialLinks.css
@@ -1,0 +1,5 @@
+.social-header {
+  svg.icon.custom-icon {
+    margin-top: 3px;
+  }
+}

--- a/src/components/icons/twitter-x.svg
+++ b/src/components/icons/twitter-x.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-twitter-x" viewBox="0 0 16 16">
+  <path d="M12.6.75h2.454l-5.36 6.142L16 15.25h-4.937l-3.867-5.07-4.425 5.07H.316l5.733-6.57L0 .75h5.063l3.495 4.633L12.601.75Zm-.86 13.028h1.36L4.323 2.145H2.865z"/>
+</svg>


### PR DESCRIPTION
Here https://react.semantic-ui.com/elements/icon/#brandsicons-can-represent-logos-to-common-brands among the semantic-ui icons I didn't find the new twitter X icon, I made this temporary fix to add it in case "twitter-x" is written in the configuration.

<img width="273" alt="Screenshot 2024-10-16 alle 17 49 20" src="https://github.com/user-attachments/assets/7952b708-6a37-480b-9b24-a022d09fec67">
